### PR TITLE
Add computed sort key

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -25,7 +25,11 @@ export type OrderBy =
   | { [key: string]: Direction }
 
 export type SortKey =
-  | { column: string; direction: Direction }[]
+  | {
+      column: string
+      key?: (table?: string) => string
+      direction: Direction
+    }[]
   | {
       order: Direction
       key: string | string[]

--- a/dist/stringifiers/shared.js
+++ b/dist/stringifiers/shared.js
@@ -69,6 +69,7 @@ function sortKeyToOrderings(sortKey, args) {
   if (Array.isArray(sortKey)) {
     for (const {
       column,
+      key,
       direction
     } of sortKey) {
       (0, _assert.default)(column, `Each "sortKey" array entry must have a 'column' and a 'direction' property`);
@@ -76,6 +77,7 @@ function sortKeyToOrderings(sortKey, args) {
       if (flip) descending = !descending;
       orderColumns.push({
         column,
+        key,
         direction: descending ? 'DESC' : 'ASC'
       });
     }
@@ -164,8 +166,20 @@ FROM (
 function orderingsToString(orderings, q, as) {
   const orderByClauses = [];
 
-  for (const ordering of orderings) {
-    orderByClauses.push(`${as ? q(as) + '.' : ''}${q(ordering.column)} ${ordering.direction}`);
+  for (const {
+    column,
+    key,
+    direction
+  } of orderings) {
+    let sortKey;
+
+    if (key) {
+      sortKey = key(as);
+    } else {
+      sortKey = `${as ? q(as) + '.' : ''}${q(column)}`;
+    }
+
+    orderByClauses.push(`${sortKey} ${direction}`);
   }
 
   return orderByClauses.join(', ');

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -82,7 +82,7 @@ const User = new GraphQLObjectType({
 })
 ```
 
-- Similarly, add support for explicit `sortKey` column orderings by passing an array of `{ column, direction }` objects. Useful for dynamically generating `sortKey`s for connection pagination without relying on object insertion order. Example:
+- Similarly, add support for explicit `sortKey` column orderings by passing an array of `{ column, key, direction }` objects. Useful for dynamically generating `sortKey`s for connection pagination without relying on object insertion order. Example:
 
 ```javascript
 const User = new GraphQLObjectType({
@@ -96,7 +96,8 @@ const User = new GraphQLObjectType({
           sqlPaginate: true,
           sortKey: [
             { column: 'created_at', direction: 'desc' },
-            { column: 'id', order: 'desc' }
+            { column: 'id', order: 'desc' },
+            { column: 'json', key: '"json"->\'field\'' order: 'desc' }
           ],
           sqlJoin: (userTable, postTable) =>
             `${userTable}.id = ${postTable}.author_id`
@@ -107,7 +108,7 @@ const User = new GraphQLObjectType({
 })
 ```
 
-The old `sortKey` synax (as an object looking like `{key, order}`) continues to work but is no longer recommended. The new syntax allows for reliable sortKey ordering as well as independent directions per sort key, with all the complicated SQL generation handled for you.
+The old `sortKey` synax (as an object looking like `{key, order}`) continues to work but is no longer recommended. The new syntax allows for reliable `sortKey` ordering as well as independent directions per sort key, with all the complicated SQL generation handled for you. The `key` field is optional, and will be used instead of the column to order the results. This is useful, for example, in Postgres, where one may sort by some key into a JSON blob.
 
 - Add support for resolving GraphQL scalars backed by `sqlTable`s. Usually, scalars point to table columns, but this allows them to use the same `extensions` property to declare that the scalar is a whole table. This is often paired with a `resolve` function that takes what `join-monster` returns and turns it into a valid value for the scalar. An example would be a tags field that outputs a list of strings, but where each tag is actually stored as it's own row in a different table in the database, or backing a `JSONScalar` by a table to get around GraphQL's type strictness.
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,7 +25,11 @@ export type OrderBy =
   | { [key: string]: Direction }
 
 export type SortKey =
-  | { column: string; direction: Direction }[]
+  | {
+      column: string
+      key?: (table?: string) => string
+      direction: Direction
+    }[]
   | {
       order: Direction
       key: string | string[]

--- a/src/stringifiers/shared.js
+++ b/src/stringifiers/shared.js
@@ -50,7 +50,7 @@ export function sortKeyToOrderings(sortKey, args) {
   }
 
   if (Array.isArray(sortKey)) {
-    for (const { column, direction } of sortKey) {
+    for (const { column, key, direction } of sortKey) {
       assert(
         column,
         `Each "sortKey" array entry must have a 'column' and a 'direction' property`
@@ -58,7 +58,7 @@ export function sortKeyToOrderings(sortKey, args) {
       let descending = direction.toUpperCase() === 'DESC'
       if (flip) descending = !descending
 
-      orderColumns.push({ column, direction: descending ? 'DESC' : 'ASC' })
+      orderColumns.push({ column, key, direction: descending ? 'DESC' : 'ASC' })
     }
   } else {
     assert(sortKey.order, 'A "sortKey" object must have an "order"')
@@ -151,10 +151,15 @@ FROM (
 
 export function orderingsToString(orderings, q, as) {
   const orderByClauses = []
-  for (const ordering of orderings) {
-    orderByClauses.push(
-      `${as ? q(as) + '.' : ''}${q(ordering.column)} ${ordering.direction}`
-    )
+  for (const { column, key, direction } of orderings) {
+    let sortKey
+    if(key) {
+      sortKey = key(as)
+    } else {
+      sortKey = `${as ? q(as) + '.' : ''}${q(column)}`
+    }
+
+    orderByClauses.push(`${sortKey} ${direction}`)
   }
   return orderByClauses.join(', ')
 }


### PR DESCRIPTION
When not provided, the column will be used. This is the same as the previous behaviour.

When a key function is provided, it takes the table name as an argument and returns the key on which to sort. This is useful, for example, in PostgreSQL when sorting on some field in a JSON column (e.g., `ORDER BY "table"."field"->'column'`).